### PR TITLE
feat: #4 ボード機能_投稿画面の実装

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -12,7 +12,7 @@ class BoardsController < ApplicationController
     @board = current_user.boards.build(board_params)
 
     if @board.save
-      redirect_to board_path(@board), notice: "ボードが作成されました"
+      redirect_to board_path(@board), notice: 'ボードが作成されました'
     else
       render :new
     end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,0 +1,39 @@
+class BoardsController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+
+  def index
+  end
+
+  def new
+    @board = current_user.boards.build
+  end
+
+  def create
+    @board = current_user.boards.build(board_params)
+
+    if @board.save
+      redirect_to board_path(@board), notice: "ボードが作成されました"
+    else
+      render :new
+    end
+  end
+
+  def show
+    @board = current_user.boards.find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+
+  def board_params
+    params.require(:board).permit(:name, :description)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,0 @@
-class HomeController < ApplicationController
-  def index
-  end
-end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: boards
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_boards_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Board < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -19,4 +19,5 @@
 #
 class Board < ApplicationRecord
   belongs_to :user
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one_attached :avatar
+  has_many :boards
 
   def avatar_image
     self.avatar&.attached? ? avatar : 'avatar.svg'

--- a/app/views/boards/index.html.haml
+++ b/app/views/boards/index.html.haml
@@ -1,0 +1,1 @@
+=link_to "新規ボード作成", new_board_path

--- a/app/views/boards/new.html.haml
+++ b/app/views/boards/new.html.haml
@@ -1,0 +1,20 @@
+.w-full.max-w-sm.mx-auto.overflow-hidden.bg-white.rounded-lg.shadow-md
+  .px-6.py-6
+    %h2.mt-3.text-xl.font-medium.text-center.text-gray-600 New Board
+    - if @board.errors.any?
+      %div.bg-red-100.border.border-red-400.text-red-700.px-4.py-3.rounded.my-4
+        %ul
+          - @board.errors.full_messages.each do |message|
+            %li= message
+
+    = form_with(model: @board, local: true, data: { turbo: false }) do |f|
+      .w-full.mt-4
+        %label{ for: "name", class: "block text-sm text-gray-500" }
+          Name
+        = f.text_field :name, class: "block mt-2 w-full placeholder-gray-400/70 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-gray-700 focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+      .w-full.mt-4
+        %label{ for: "description", class: "block text-sm text-gray-500" }
+          Description
+        = f.text_area :description, class: "block mt-2 w-full placeholder-gray-400/70 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-gray-700 focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+      .flex.items-center.justify-center.mt-4
+        = f.submit "Save", class: "px-6 py-2 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-500 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-50"

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -1,0 +1,4 @@
+%h2.text-lg.font-bold Name
+=@board.name
+%h2.text-lg.font-bold Description
+=@board.description

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,1 +1,0 @@
-Home Page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations' }
-  root to: 'home#index'
+  root to: 'boards#index'
+  resources :boards
 end

--- a/db/migrate/20250922145309_create_boards.rb
+++ b/db/migrate/20250922145309_create_boards.rb
@@ -1,0 +1,10 @@
+class CreateBoards < ActiveRecord::Migration[7.2]
+  def change
+    create_table :boards do |t|
+      t.string :name, null: false
+      t.text :description
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_19_133201) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_22_145309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_133201) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "boards", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_boards_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -57,4 +66,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_19_133201) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "boards", "users"
 end


### PR DESCRIPTION
## 該当 issue

CLOSE #4 

## 概要

### Boards テーブル作成 (a92a3c1)
- Boardモデル作成（User との1対多関連）
- マイグレーション: name(必須), description, user_id
- 外部キー制約とインデックス設定

### Board new/create機能 (7394757)
- BoardsController で、new / create / show までのアクションを実装
- フォームバリデーション + エラー表示の実装
- index アクション以外にログイン制約

### 実装済み機能
- [x] board 新規作成（new/create）
- [x]  board 詳細簡易表示（show）
- [x] 認証制御（ログイン必須）

### TODO: 次の実装予定
- ボード一覧表示（index）
- ボード詳細表示 View の改善（show）
- ボード編集機能（edit/update）
- ボード削除機能（destroy）


## スクリーンショット・動画

https://github.com/user-attachments/assets/66d02605-99ec-4b4a-a9a2-035e3a9d6f12



