### PR TITLE
feat: #14 タスク機能_投稿機能の実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,31 @@
+class TasksController < ApplicationController
+    before_action :authenticate_user!, except: [:show]
+
+    def new
+        @board = current_user.boards.find(params[:board_id])
+        @task = @board.tasks.build
+    end
+
+    def create
+        @board = current_user.boards.find(params[:board_id])
+        @task = current_user.tasks.build(task_params.merge(board: @board))
+
+        if @task.save
+            redirect_to board_task_path(@board.id, @task.id), notice: 'タスクが作成されました'
+        else
+            render :new, status: :unprocessable_entity
+        end
+    end
+
+    def show
+        @board = Board.find(params[:board_id])
+        @task = @board.tasks.find(params[:id])
+    end
+
+    private
+
+    def task_params
+        params.require(:task).permit(:name, :description, :due_date)
+    end
+
+end

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -1,2 +1,3 @@
 %div.grid.grid-cols-1.gap-6.p-6.bg-white.shadow-lg.rounded-lg
     =render 'commons/board-card', board: @board, show_read_more: false
+    =link_to "Add new Task", new_board_task_path(@board)

--- a/app/views/commons/_task-form.html.haml
+++ b/app/views/commons/_task-form.html.haml
@@ -1,0 +1,15 @@
+= form_with(model: [@board, task], local: true, data: { turbo: false }) do |f|
+    .w-full.mt-4
+        %label{ for: "task_name", class: "w-fit cursor-pointer block text-sm text-gray-500" }
+            Name
+        = f.text_field :name, class: "block mt-2 w-full placeholder-gray-400/70 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-gray-700 focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+    .w-full.mt-4
+        %label{ for: "task_description", class: "w-fit cursor-pointer block text-sm text-gray-500" }
+            Description
+        = f.text_area :description, class: "block mt-2 w-full placeholder-gray-400/70 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-gray-700 focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+    .w-full.mt-4
+        %label{ for: "task_due_date", class: "w-fit cursor-pointer block text-sm text-gray-500" }
+            Due Date
+        = f.date_field :due_date, class: "block mt-2 w-full placeholder-gray-400/70 rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-gray-700 focus:border-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+    .flex.items-center.justify-center.mt-4
+        = f.submit "Save", class: "px-6 py-2 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-500 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-50"

--- a/app/views/tasks/new.html.haml
+++ b/app/views/tasks/new.html.haml
@@ -1,0 +1,9 @@
+.w-full.max-w-sm.mx-auto.overflow-hidden.bg-white.rounded-lg.shadow-md
+  .px-6.py-6
+    %h2.mt-3.text-xl.font-medium.text-center.text-gray-600 New Task
+    - if @task.errors.any?
+      %div.bg-red-100.border.border-red-400.text-red-700.px-4.py-3.rounded.my-4
+        %ul
+          - @task.errors.full_messages.each do |message|
+            %li= message
+    =render "commons/task-form", task: @task

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,0 +1,8 @@
+-# TODO: show画面のスタイル調整
+%h1.text-2xl.font-bold #{@board.name} > Task
+%h2.mt-4.font-bold name
+=@task.name
+%h2.mt-4.font-bold description
+=@task.description
+%h2.mt-4.font-bold due_date
+=@task.due_date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations' }
   root to: 'boards#index'
-  resources :boards
+  resources :boards do
+    resources :tasks
+  end
 end


### PR DESCRIPTION
## 該当 issue

CLOSE #14 

## 概要

### Task 作成機能（new/create）実装
  - タスク投稿フォームの作成
  - バリデーションエラー表示
  - 作成後の詳細画面へのリダイレクト

### Task 詳細表示（show）仮実装
  - タスクの詳細情報を表示（名前、説明、期限）
  - 見栄えは #15 で調整

### 共通の task-form コンポーネント作成
  - name, description, due_date の入力フィールド

### ルーティング・権限制御
  - ネストしたリソースルーティング（boards/:id/tasks）
  - 認証ユーザーのみタスク作成可能
  - 自分のボードのみタスク作成権限

## スクリーンショット・動画

https://github.com/user-attachments/assets/cdb5c596-5ede-4a72-8cf0-fd93c7edf67a