### PR TITLE
fix: タスクステータス API の名前空間を修正

### DIFF
--- a/app/controllers/api/v1/tasks/statuses_controller.rb
+++ b/app/controllers/api/v1/tasks/statuses_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::StatusesController < ApplicationController
+class Api::V1::Tasks::StatusesController < ApplicationController
   before_action :authenticate_user!
 
   def update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :tasks, only: %i() do
-        resource :status, only: %i(update)
+        resource :status, only: %i(update), module: :tasks
       end
     end
   end


### PR DESCRIPTION

## 概要
- コントローラーのクラス名を更新 Api::V1::Tasks::StatusesController 
- コントローラに適切にルーティングされるよう routes を更新